### PR TITLE
Fix report rendering (hopefully)

### DIFF
--- a/app.R
+++ b/app.R
@@ -7,7 +7,6 @@ library(scales)
 library(RColorBrewer)
 library(plotly)
 library(shinythemes)
-library(callr)
 
 
 
@@ -19,12 +18,12 @@ temp_report_path <- tempfile(fileext = ".Rmd")
 file.copy("report.Rmd", temp_report_path, overwrite = TRUE)
 
 # Render report for downloading
-render_report <- function(input, output, params) {
+render_report <- function(output, params) {
   # Knit the document, passing in the `params` list, and eval it in a
   # child of the global environment (this isolates the code in the document
   # from the code in this app).
   rmarkdown::render(
-    input,
+    temp_report_path,
     output_file = output,
     params = params,
     envir = new.env(parent = globalenv())
@@ -388,10 +387,7 @@ server <- function(input, output, session) {
     content = function(file) {
       data <- get_data_sliders()
       params <- get_report_params(data)
-      callr::r(
-        render_report,
-        list(input = temp_report_path, output = file, params = params)
-      )
+      render_report(output = file, params = params)
     }
   )
   
@@ -401,10 +397,8 @@ server <- function(input, output, session) {
     content = function(file) {
       data <- get_data_sliders()
       params <- get_report_params(data)
-      callr::r(
-        render_report,
-        list(input = temp_report_path, output = file, params = params)
-      )
+      render_report(output = file, params = params)
+      
     }
   )
   

--- a/report.rmd
+++ b/report.rmd
@@ -12,19 +12,21 @@ params:
 
 ## Foods Input:
 ```{r echo=FALSE}
-params$input_foods |> knitr::kable(digits=2)
+# params$input_foods |> knitr::kable(digits=2)
+x <- 1
+x
 ```
 
 
 ## Macronutrient Totals:
 ```{r fig.height=4, fig.width=12, echo=FALSE}
-params$totals |> knitr::kable(digits=2)
-params$main_plot
+# params$totals |> knitr::kable(digits=2)
+# params$main_plot
 ```
 
 
 ## Macronutrient Proportions:
 ```{r fig.height=3, fig.width=12, echo=FALSE}
-params$proportions |> knitr::kable(digits=3)
-params$sub_plot
+# params$proportions |> knitr::kable(digits=3)
+# params$sub_plot
 ```


### PR DESCRIPTION
Removed `callr` because Florencia said that might help (even tho [this](https://mastering-shiny.org/action-transfer.html#downloading-reports:~:text=There%20are%20a%20couple%20of%20other%20tricks%20worth%20knowing%20about%3A) suggests otherwise).
Also simplified the report down to barebones to test if that's the issue. 